### PR TITLE
Add tool dashboard and dynamic Fixly.dev experience

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+from datetime import datetime
+import re
+
+from flask import (
+    Flask,
+    abort,
+    flash,
+    redirect,
+    render_template,
+    request,
+    url_for,
+)
+from flask_sqlalchemy import SQLAlchemy
+
+app = Flask(__name__)
+app.config.update(
+    SECRET_KEY="dev-secret-key-change-me",
+    SQLALCHEMY_DATABASE_URI="sqlite:///fixly.db",
+    SQLALCHEMY_TRACK_MODIFICATIONS=False,
+)
+
+db = SQLAlchemy(app)
+
+
+class Tool(db.Model):
+    __tablename__ = "tools"
+
+    id = db.Column(db.Integer, primary_key=True)
+    title = db.Column(db.String(140), nullable=False)
+    slug = db.Column(db.String(160), unique=True, nullable=False)
+    summary = db.Column(db.String(280), nullable=False)
+    content = db.Column(db.Text, nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+    is_published = db.Column(db.Boolean, default=True, nullable=False)
+
+    def __repr__(self) -> str:  # pragma: no cover - debug helper
+        return f"<Tool {self.title!r}>"
+
+
+def slugify(value: str) -> str:
+    """Create a URL-friendly slug from the provided value."""
+
+    slug = re.sub(r"[^a-z0-9\s-]", "", value.lower())
+    slug = re.sub(r"[\s-]+", "-", slug).strip("-")
+
+    if not slug:
+        slug = f"tool-{int(datetime.utcnow().timestamp())}"
+
+    return slug
+
+
+@app.before_first_request
+def create_tables() -> None:
+    db.create_all()
+
+
+@app.context_processor
+def inject_globals():
+    return {
+        "brand_name": "Fixly.dev",
+        "brand_domain": "fixly.dev",
+        "brand_tagline": "SaaS builder for 400+ developer automations",
+        "brand_url": url_for("index"),
+        "admin_tools_url": url_for("admin_tools"),
+        "current_year": datetime.now().year,
+    }
+
+
+@app.template_filter("paragraphs")
+def paragraphs(value: str | None) -> list[str]:
+    if not value:
+        return []
+
+    return [segment.strip() for segment in value.split("\n") if segment.strip()]
+
+
+@app.route("/")
+def index():
+    tools = (
+        Tool.query.filter_by(is_published=True)
+        .order_by(Tool.created_at.desc())
+        .all()
+    )
+
+    return render_template("home.html", tools=tools)
+
+
+@app.route("/tools/<string:slug>")
+def tool_detail(slug: str):
+    tool = Tool.query.filter_by(slug=slug, is_published=True).first()
+    if tool is None:
+        abort(404)
+
+    return render_template("tool_detail.html", tool=tool)
+
+
+@app.route("/admin/tools", methods=["GET", "POST"])
+def admin_tools():
+    if request.method == "POST":
+        title = request.form.get("title", "").strip()
+        summary = request.form.get("summary", "").strip()
+        content = request.form.get("content", "").strip()
+
+        if not title or not summary or not content:
+            flash("Please provide a title, summary, and detailed content.", "error")
+        else:
+            base_slug = slugify(title)
+            slug_candidate = base_slug
+            index = 1
+
+            while Tool.query.filter_by(slug=slug_candidate).first() is not None:
+                index += 1
+                slug_candidate = f"{base_slug}-{index}"
+
+            tool = Tool(
+                title=title,
+                summary=summary,
+                content=content,
+                slug=slug_candidate,
+                is_published=True,
+            )
+
+            db.session.add(tool)
+            db.session.commit()
+
+            flash("“{}” is live on the Fixly.dev homepage.".format(tool.title), "success")
+            return redirect(url_for("admin_tools"))
+
+    tools = Tool.query.order_by(Tool.created_at.desc()).all()
+    return render_template("admin/tools.html", tools=tools)
+
+
+@app.post("/admin/tools/<int:tool_id>/toggle")
+def toggle_tool(tool_id: int):
+    tool = Tool.query.get_or_404(tool_id)
+    tool.is_published = not tool.is_published
+    db.session.commit()
+
+    state = "published" if tool.is_published else "hidden"
+    flash("“{}” is now {}.".format(tool.title, state), "info")
+    return redirect(url_for("admin_tools"))
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/app.py
+++ b/app.py
@@ -39,6 +39,21 @@ class Tool(db.Model):
         return f"<Tool {self.title!r}>"
 
 
+class Post(db.Model):
+    __tablename__ = "posts"
+
+    id = db.Column(db.Integer, primary_key=True)
+    title = db.Column(db.String(160), nullable=False)
+    slug = db.Column(db.String(180), unique=True, nullable=False)
+    excerpt = db.Column(db.String(280), nullable=False)
+    content = db.Column(db.Text, nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+    is_published = db.Column(db.Boolean, default=True, nullable=False)
+
+    def __repr__(self) -> str:  # pragma: no cover - debug helper
+        return f"<Post {self.title!r}>"
+
+
 def slugify(value: str) -> str:
     """Create a URL-friendly slug from the provided value."""
 
@@ -64,6 +79,8 @@ def inject_globals():
         "brand_tagline": "SaaS builder for 400+ developer automations",
         "brand_url": url_for("index"),
         "admin_tools_url": url_for("admin_tools"),
+        "admin_posts_url": url_for("admin_posts"),
+        "blog_url": url_for("blog_index"),
         "current_year": datetime.now().year,
     }
 
@@ -84,7 +101,14 @@ def index():
         .all()
     )
 
-    return render_template("home.html", tools=tools)
+    posts = (
+        Post.query.filter_by(is_published=True)
+        .order_by(Post.created_at.desc())
+        .limit(3)
+        .all()
+    )
+
+    return render_template("home.html", tools=tools, posts=posts)
 
 
 @app.route("/tools/<string:slug>")
@@ -94,6 +118,26 @@ def tool_detail(slug: str):
         abort(404)
 
     return render_template("tool_detail.html", tool=tool)
+
+
+@app.route("/blog")
+def blog_index():
+    posts = (
+        Post.query.filter_by(is_published=True)
+        .order_by(Post.created_at.desc())
+        .all()
+    )
+
+    return render_template("blog_index.html", posts=posts)
+
+
+@app.route("/blog/<string:slug>")
+def blog_detail(slug: str):
+    post = Post.query.filter_by(slug=slug, is_published=True).first()
+    if post is None:
+        abort(404)
+
+    return render_template("blog_detail.html", post=post)
 
 
 @app.route("/admin/tools", methods=["GET", "POST"])
@@ -132,6 +176,48 @@ def admin_tools():
     return render_template("admin/tools.html", tools=tools)
 
 
+@app.route("/admin/posts", methods=["GET", "POST"])
+def admin_posts():
+    if request.method == "POST":
+        title = request.form.get("title", "").strip()
+        excerpt = request.form.get("excerpt", "").strip()
+        content = request.form.get("content", "").strip()
+
+        if not title or not content:
+            flash("Posts need a title and content before publishing.", "error")
+        else:
+            if not excerpt:
+                excerpt_candidate = content.strip()
+                if len(excerpt_candidate) > 200:
+                    excerpt_candidate = excerpt_candidate[:200].rsplit(" ", 1)[0]
+                excerpt = excerpt_candidate or content[:200]
+
+            base_slug = slugify(title)
+            slug_candidate = base_slug
+            index = 1
+
+            while Post.query.filter_by(slug=slug_candidate).first() is not None:
+                index += 1
+                slug_candidate = f"{base_slug}-{index}"
+
+            post = Post(
+                title=title,
+                excerpt=excerpt,
+                content=content,
+                slug=slug_candidate,
+                is_published=True,
+            )
+
+            db.session.add(post)
+            db.session.commit()
+
+            flash("Blog post “{}” is live on Fixly.dev.".format(post.title), "success")
+            return redirect(url_for("admin_posts"))
+
+    posts = Post.query.order_by(Post.created_at.desc()).all()
+    return render_template("admin/posts.html", posts=posts)
+
+
 @app.post("/admin/tools/<int:tool_id>/toggle")
 def toggle_tool(tool_id: int):
     tool = Tool.query.get_or_404(tool_id)
@@ -141,6 +227,17 @@ def toggle_tool(tool_id: int):
     state = "published" if tool.is_published else "hidden"
     flash("“{}” is now {}.".format(tool.title, state), "info")
     return redirect(url_for("admin_tools"))
+
+
+@app.post("/admin/posts/<int:post_id>/toggle")
+def toggle_post(post_id: int):
+    post = Post.query.get_or_404(post_id)
+    post.is_published = not post.is_published
+    db.session.commit()
+
+    state = "published" if post.is_published else "hidden"
+    flash("“{}” is now {}.".format(post.title, state), "info")
+    return redirect(url_for("admin_posts"))
 
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask>=2.3
+Flask-SQLAlchemy>=3.1

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -921,6 +921,199 @@ textarea:focus {
   color: var(--accent-strong);
 }
 
+.dashboard__switcher {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: center;
+  align-items: center;
+  margin-top: 1.5rem;
+  color: var(--text-muted);
+  font-size: 0.95rem;
+}
+
+.dashboard__switcher-link {
+  color: inherit;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.dashboard__switcher-link:hover {
+  color: var(--accent-strong);
+}
+
+.dashboard__switcher-current {
+  font-weight: 600;
+  color: var(--accent);
+}
+
+.section--blog {
+  background: linear-gradient(180deg, rgba(21, 24, 35, 0.6), rgba(21, 24, 35, 0.9));
+}
+
+.section--blog .section__intro {
+  text-align: left;
+}
+
+.blog-grid {
+  display: grid;
+  gap: 2rem;
+  margin-top: 3rem;
+}
+
+.blog-card {
+  background: rgba(28, 31, 44, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: 1.5rem;
+  padding: 2rem;
+  display: grid;
+  gap: 1rem;
+  min-height: 100%;
+  transition: transform 150ms ease, border-color 150ms ease;
+}
+
+.blog-card:hover {
+  transform: translateY(-4px);
+  border-color: rgba(111, 78, 246, 0.45);
+}
+
+.blog-card__header {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.blog-card__eyebrow {
+  margin: 0;
+  font-size: 0.85rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+
+.blog-card__title {
+  margin: 0;
+  font-size: 1.45rem;
+  line-height: 1.3;
+}
+
+.blog-card__title a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.blog-card__title a:hover {
+  color: var(--accent-strong);
+}
+
+.blog-card__excerpt {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 1.05rem;
+  line-height: 1.6;
+}
+
+.blog-card__footer {
+  margin-top: auto;
+}
+
+.blog-card__link {
+  color: var(--accent);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.blog-card__link:hover {
+  color: var(--accent-strong);
+}
+
+.section__cta {
+  margin-top: 2.5rem;
+  display: flex;
+  justify-content: center;
+}
+
+.hero--blog,
+.hero--blog-detail {
+  background: radial-gradient(circle at top left, rgba(111, 78, 246, 0.35), transparent 45%),
+    radial-gradient(circle at top right, rgba(0, 255, 209, 0.2), transparent 55%),
+    linear-gradient(180deg, rgba(21, 24, 35, 0.95), rgba(11, 13, 22, 0.98));
+  padding-block: 4rem 3rem;
+}
+
+.hero--blog__inner,
+.hero--blog-detail__inner {
+  max-width: 720px;
+  margin: 0 auto;
+}
+
+.hero--blog-detail__inner {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.hero__breadcrumb {
+  color: var(--accent);
+  text-decoration: none;
+  font-size: 0.9rem;
+}
+
+.hero__breadcrumb:hover {
+  color: var(--accent-strong);
+}
+
+.hero--blog-detail .hero__meta {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+}
+
+.section--blog-detail {
+  background: #080a12;
+}
+
+.blog-article {
+  max-width: 760px;
+  display: grid;
+  gap: 1.5rem;
+}
+
+.blog-article p {
+  margin: 0;
+  font-size: 1.1rem;
+  line-height: 1.8;
+  color: var(--text-primary);
+}
+
+.section--blog-index {
+  background: linear-gradient(180deg, rgba(11, 13, 22, 0.95), rgba(11, 13, 22, 1));
+}
+
+.blog-card--index {
+  padding: 2.25rem;
+}
+
+@media (min-width: 768px) {
+  .blog-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .blog-grid--index {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .section__cta {
+    justify-content: flex-start;
+  }
+
+  .hero--blog,
+  .hero--blog-detail {
+    padding-block: 6rem 4rem;
+  }
+
+  .dashboard__switcher {
+    justify-content: flex-start;
+  }
+}
+
 /* Responsive */
 
 @media (min-width: 768px) {

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -1,0 +1,996 @@
+:root {
+  color-scheme: light;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --page-bg: #070618;
+  --surface: #0e0d25;
+  --surface-alt: rgba(255, 255, 255, 0.06);
+  --surface-card: rgba(12, 11, 35, 0.85);
+  --gradient-primary: linear-gradient(135deg, #6f4ef6, #b368ff);
+  --gradient-secondary: radial-gradient(circle at 0% 0%, rgba(111, 78, 246, 0.3), transparent 60%),
+    radial-gradient(circle at 100% 0%, rgba(32, 217, 210, 0.25), transparent 55%);
+  --text-primary: #f4f5fb;
+  --text-secondary: rgba(240, 242, 255, 0.72);
+  --text-muted: rgba(240, 242, 255, 0.55);
+  --accent: #20d9d2;
+  --accent-strong: #38e9f0;
+  --warning: #f6a94e;
+  --danger: #ff6f91;
+  --border: rgba(255, 255, 255, 0.08);
+  --shadow-soft: 0 24px 60px rgba(8, 11, 32, 0.45);
+  --transition: 180ms ease;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--page-bg);
+  background-image: var(--gradient-secondary);
+  color: var(--text-primary);
+  line-height: 1.6;
+}
+
+body.nav-open {
+  overflow: hidden;
+}
+
+img {
+  max-width: 100%;
+  height: auto;
+  display: block;
+}
+
+.container {
+  width: min(1120px, 92%);
+  margin: 0 auto;
+}
+
+.page {
+  position: relative;
+}
+
+.page__content {
+  display: flex;
+  flex-direction: column;
+  gap: 5rem;
+  padding-block: 4rem 6rem;
+}
+
+.skip-link {
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  top: -100%;
+  padding: 0.75rem 1.5rem;
+  background: var(--surface-card);
+  color: var(--text-primary);
+  border-radius: 999px;
+  z-index: 999;
+  transition: top var(--transition);
+}
+
+.skip-link:focus {
+  top: 1rem;
+}
+
+/* Header */
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  background: rgba(7, 6, 24, 0.92);
+  backdrop-filter: blur(16px);
+  border-bottom: 1px solid var(--border);
+}
+
+.site-header__inner {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+  padding: 1rem 0;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  text-decoration: none;
+  color: inherit;
+}
+
+.brand__mark {
+  display: grid;
+  place-items: center;
+  width: 3rem;
+  height: 3rem;
+  background: var(--gradient-primary);
+  border-radius: 1.25rem;
+  font-size: 1.4rem;
+  box-shadow: 0 10px 30px rgba(111, 78, 246, 0.4);
+}
+
+.brand__text {
+  display: flex;
+  flex-direction: column;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+
+.brand__subtext {
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: var(--text-muted);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.nav-toggle {
+  margin-left: auto;
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 0.5rem 1.1rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--text-primary);
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.nav-toggle__icon {
+  width: 1.25rem;
+  height: 1.25rem;
+  position: relative;
+}
+
+.nav-toggle__icon::before,
+.nav-toggle__icon::after,
+.nav-toggle__icon span {
+  content: '';
+  position: absolute;
+  left: 0;
+  width: 100%;
+  height: 2px;
+  background: currentColor;
+  transition: transform var(--transition), opacity var(--transition);
+}
+
+.nav-toggle__icon::before {
+  top: 0;
+}
+
+.nav-toggle__icon::after {
+  bottom: 0;
+}
+
+.nav-toggle.is-active .nav-toggle__icon::before {
+  transform: translateY(6px) rotate(45deg);
+}
+
+.nav-toggle.is-active .nav-toggle__icon::after {
+  transform: translateY(-6px) rotate(-45deg);
+}
+
+.nav-toggle.is-active .nav-toggle__icon span {
+  opacity: 0;
+}
+
+.primary-nav {
+  position: fixed;
+  inset: 0 0 auto 0;
+  background: rgba(7, 6, 24, 0.96);
+  padding: 6rem 2rem 2rem;
+  transform: translateY(-100%);
+  transition: transform var(--transition);
+}
+
+.primary-nav.is-open {
+  transform: translateY(0);
+}
+
+.primary-nav__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.primary-nav__item {
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.primary-nav__link {
+  color: var(--text-primary);
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.primary-nav__link:hover {
+  color: var(--accent-strong);
+}
+
+.primary-nav__link--muted {
+  color: var(--text-muted);
+}
+
+.primary-nav__cta {
+  margin-top: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.site-header__announcement {
+  border-top: 1px solid var(--border);
+  background: rgba(111, 78, 246, 0.1);
+}
+
+.site-header__announcement-inner {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.85rem 0;
+  font-size: 0.95rem;
+}
+
+.site-header__announcement-link {
+  color: var(--accent);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+/* Buttons */
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  padding: 0.75rem 1.4rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  font-weight: 600;
+  text-decoration: none;
+  cursor: pointer;
+  transition: transform var(--transition), box-shadow var(--transition), background var(--transition);
+}
+
+.button--primary {
+  background: var(--gradient-primary);
+  color: #0b0a1b;
+  box-shadow: 0 12px 35px rgba(111, 78, 246, 0.45);
+}
+
+.button--primary:hover {
+  transform: translateY(-1px);
+}
+
+.button--ghost {
+  background: transparent;
+  border-color: var(--border);
+  color: var(--text-primary);
+}
+
+.button--ghost:hover {
+  border-color: var(--accent);
+  color: var(--accent-strong);
+}
+
+.button--secondary {
+  background: rgba(111, 78, 246, 0.2);
+  color: var(--text-primary);
+  border-color: rgba(111, 78, 246, 0.5);
+}
+
+.button--disabled {
+  opacity: 0.5;
+  pointer-events: none;
+}
+
+/* Flash */
+
+.flash-region {
+  width: min(700px, 90%);
+  margin: -1rem auto 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.flash {
+  padding: 0.9rem 1.3rem;
+  border-radius: 0.9rem;
+  background: rgba(32, 217, 210, 0.12);
+  border: 1px solid rgba(32, 217, 210, 0.3);
+  color: var(--text-primary);
+  font-weight: 500;
+}
+
+.flash--error {
+  background: rgba(255, 111, 145, 0.15);
+  border-color: rgba(255, 111, 145, 0.35);
+}
+
+.flash--info {
+  background: rgba(111, 78, 246, 0.15);
+  border-color: rgba(111, 78, 246, 0.35);
+}
+
+/* Hero */
+
+.hero {
+  position: relative;
+  padding-block: 5rem;
+  overflow: hidden;
+}
+
+.hero::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 20% 10%, rgba(111, 78, 246, 0.5), transparent 55%),
+    radial-gradient(circle at 90% 30%, rgba(32, 217, 210, 0.4), transparent 60%);
+  opacity: 0.8;
+  pointer-events: none;
+}
+
+.hero__grid {
+  position: relative;
+  display: grid;
+  gap: 3rem;
+}
+
+.hero__content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+}
+
+.hero__title {
+  font-size: clamp(2.5rem, 4vw + 1rem, 4rem);
+  line-height: 1.1;
+  letter-spacing: -0.02em;
+  margin: 0;
+}
+
+.hero__description {
+  margin: 0;
+  color: var(--text-secondary);
+  max-width: 40rem;
+}
+
+.hero__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.hero__stats {
+  display: grid;
+  gap: 1.25rem;
+  margin: 0;
+}
+
+.hero__stats div {
+  display: flex;
+  gap: 0.75rem;
+  align-items: baseline;
+  color: var(--text-secondary);
+  font-weight: 600;
+}
+
+.hero__stats dt {
+  font-size: 0.95rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.hero__stats dd {
+  margin: 0;
+  font-size: 1.4rem;
+  color: var(--accent-strong);
+}
+
+.hero__media {
+  display: flex;
+  justify-content: center;
+}
+
+.dashboard-card {
+  background: var(--surface-card);
+  border-radius: 1.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  box-shadow: var(--shadow-soft);
+  min-width: min(340px, 100%);
+  display: flex;
+  flex-direction: column;
+}
+
+.dashboard-card__header,
+.dashboard-card__footer {
+  padding: 1.4rem 1.6rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.dashboard-card__footer {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  border-bottom: 0;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.95rem;
+}
+
+.dashboard-card__eyebrow {
+  display: block;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--text-muted);
+  margin-bottom: 0.35rem;
+}
+
+.dashboard-card__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.dashboard-card__list li {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 1rem;
+  padding: 1.1rem 1.6rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+  font-size: 0.95rem;
+}
+
+.dashboard-card__status {
+  font-weight: 600;
+  color: var(--accent);
+}
+
+.dashboard-card__cta {
+  color: var(--text-muted);
+  font-weight: 600;
+}
+
+/* Sections */
+
+.section {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 3rem;
+}
+
+.section--accent {
+  background: rgba(255, 255, 255, 0.02);
+  border-block: 1px solid rgba(255, 255, 255, 0.05);
+  padding-block: 5rem;
+}
+
+.section--pricing {
+  padding-block: 5rem 6rem;
+}
+
+.section__intro {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  max-width: 48rem;
+}
+
+.section__title {
+  font-size: clamp(2rem, 3vw + 1rem, 3.2rem);
+  margin: 0;
+}
+
+.section__description {
+  margin: 0;
+  color: var(--text-secondary);
+}
+
+.eyebrow {
+  margin: 0;
+  font-size: 0.78rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--accent);
+  font-weight: 700;
+}
+
+.tool-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.75rem;
+}
+
+.tool-card {
+  background: var(--surface-card);
+  border-radius: 1.5rem;
+  padding: 1.75rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  box-shadow: var(--shadow-soft);
+}
+
+.tool-card header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.tool-card h3 {
+  margin: 0;
+  font-size: 1.3rem;
+}
+
+.tool-card__badge {
+  background: rgba(32, 217, 210, 0.15);
+  color: var(--accent-strong);
+  padding: 0.2rem 0.8rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+
+.tool-card__meta {
+  display: flex;
+  gap: 1rem;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+}
+
+.tool-card__link {
+  color: var(--accent-strong);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.tool-card__link:hover {
+  color: var(--accent);
+}
+
+.empty-state {
+  background: rgba(255, 255, 255, 0.03);
+  border-radius: 1.5rem;
+  padding: 3rem;
+  text-align: center;
+  border: 1px dashed rgba(255, 255, 255, 0.1);
+  display: grid;
+  gap: 1rem;
+}
+
+.empty-state--dashboard {
+  padding: 2rem;
+  text-align: left;
+}
+
+.feature-mosaic {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.5rem;
+}
+
+.feature-tile {
+  background: rgba(111, 78, 246, 0.14);
+  border-radius: 1.3rem;
+  padding: 1.75rem;
+  border: 1px solid rgba(111, 78, 246, 0.35);
+}
+
+.feature-tile h3 {
+  margin-top: 0;
+}
+
+.automation-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.5rem;
+}
+
+.automation-card {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 1.4rem;
+  padding: 1.75rem;
+}
+
+.pricing-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.5rem;
+}
+
+.pricing-card {
+  background: rgba(255, 255, 255, 0.03);
+  border-radius: 1.4rem;
+  padding: 2rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  display: grid;
+  gap: 1rem;
+}
+
+.pricing-card--featured {
+  background: rgba(111, 78, 246, 0.25);
+  border-color: rgba(111, 78, 246, 0.6);
+  box-shadow: var(--shadow-soft);
+}
+
+.pricing-card__price {
+  margin: 0;
+  font-size: 2.5rem;
+  font-weight: 700;
+}
+
+.pricing-card__price span {
+  font-size: 1rem;
+  color: var(--text-muted);
+}
+
+.pricing-card ul {
+  margin: 0;
+  padding-left: 1.1rem;
+  color: var(--text-secondary);
+  display: grid;
+  gap: 0.5rem;
+}
+
+.cta {
+  padding-block: 4rem 5rem;
+  background: linear-gradient(135deg, rgba(111, 78, 246, 0.2), rgba(32, 217, 210, 0.22));
+  border-radius: 2rem;
+  width: min(1050px, 92%);
+  margin-inline: auto;
+  box-shadow: var(--shadow-soft);
+}
+
+.cta__inner {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.cta--detail {
+  background: rgba(255, 255, 255, 0.03);
+  border-radius: 1.5rem;
+}
+
+/* Article */
+
+.section--article {
+  padding-block: 2rem 3rem;
+}
+
+.article-body {
+  display: grid;
+  gap: 1.25rem;
+  font-size: 1.05rem;
+  max-width: 680px;
+}
+
+.hero--detail {
+  padding-bottom: 2rem;
+}
+
+.hero--detail__inner {
+  display: grid;
+  gap: 1rem;
+}
+
+.back-link {
+  color: var(--accent-strong);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.hero__meta {
+  display: flex;
+  gap: 1.25rem;
+  color: var(--text-muted);
+  font-size: 0.95rem;
+}
+
+/* Dashboard */
+
+.section--dashboard {
+  padding-block: 2rem 4rem;
+}
+
+.dashboard {
+  display: grid;
+  gap: 2rem;
+}
+
+.dashboard__panel {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 1.5rem;
+  padding: 2rem;
+  display: grid;
+  gap: 1.75rem;
+  box-shadow: var(--shadow-soft);
+}
+
+.hero--dashboard__inner {
+  display: grid;
+  gap: 2rem;
+}
+
+.hero__meta--dashboard {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 1rem;
+  background: rgba(255, 255, 255, 0.05);
+  padding: 1.2rem;
+  border-radius: 1rem;
+}
+
+.hero__meta--dashboard strong {
+  font-size: 1.6rem;
+  display: block;
+}
+
+.form {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.form__field {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.form__field span {
+  font-weight: 600;
+}
+
+input[type='text'],
+textarea {
+  width: 100%;
+  padding: 0.9rem 1rem;
+  border-radius: 0.9rem;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  background: rgba(12, 11, 35, 0.65);
+  color: var(--text-primary);
+  font-size: 1rem;
+  font-family: inherit;
+  resize: vertical;
+}
+
+input[type='text']:focus,
+textarea:focus {
+  outline: 2px solid rgba(32, 217, 210, 0.6);
+  border-color: rgba(32, 217, 210, 0.4);
+}
+
+.dashboard__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1.4rem;
+}
+
+.dashboard__item {
+  display: grid;
+  gap: 1.25rem;
+  background: rgba(7, 6, 24, 0.55);
+  border-radius: 1.2rem;
+  padding: 1.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.dashboard__item h3 {
+  margin: 0 0 0.5rem;
+}
+
+.dashboard__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  color: var(--text-muted);
+  font-size: 0.95rem;
+}
+
+.dashboard__actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.dashboard__actions form {
+  margin: 0;
+}
+
+/* Footer */
+
+.site-footer {
+  background: rgba(7, 6, 24, 0.9);
+  border-top: 1px solid rgba(255, 255, 255, 0.04);
+  padding-block: 4rem 2rem;
+}
+
+.site-footer__grid {
+  display: grid;
+  gap: 3rem;
+}
+
+.site-footer__brand {
+  display: grid;
+  gap: 1rem;
+}
+
+.site-footer__mark {
+  font-size: 2rem;
+  width: 3.5rem;
+  height: 3.5rem;
+  display: grid;
+  place-items: center;
+  border-radius: 1.5rem;
+  background: rgba(111, 78, 246, 0.2);
+}
+
+.site-footer__title {
+  margin: 0;
+  font-size: 2rem;
+}
+
+.site-footer__description {
+  margin: 0;
+  color: var(--text-secondary);
+}
+
+.site-footer__meta {
+  font-size: 0.95rem;
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.site-footer__links {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 2rem;
+}
+
+.site-footer__heading {
+  margin: 0 0 0.75rem;
+  font-size: 1.05rem;
+}
+
+.site-footer__links ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.6rem;
+}
+
+.site-footer__links a {
+  color: var(--text-secondary);
+  text-decoration: none;
+}
+
+.site-footer__links a:hover {
+  color: var(--accent-strong);
+}
+
+.site-footer__bottom {
+  border-top: 1px solid rgba(255, 255, 255, 0.05);
+  margin-top: 3rem;
+  padding-top: 1.5rem;
+}
+
+.site-footer__bottom-inner {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  color: var(--text-muted);
+  font-size: 0.95rem;
+}
+
+.site-footer__policies {
+  display: flex;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.site-footer__policies a {
+  color: var(--text-secondary);
+  text-decoration: none;
+}
+
+.site-footer__policies a:hover {
+  color: var(--accent-strong);
+}
+
+/* Responsive */
+
+@media (min-width: 768px) {
+  .page__content {
+    padding-block: 5rem 7rem;
+  }
+
+  .primary-nav {
+    position: static;
+    padding: 0;
+    transform: none;
+    background: transparent;
+    display: flex;
+    align-items: center;
+    gap: 2rem;
+  }
+
+  .primary-nav__list {
+    flex-direction: row;
+    gap: 1.5rem;
+  }
+
+  .primary-nav__cta {
+    margin-top: 0;
+    flex-direction: row;
+    gap: 1rem;
+  }
+
+  .nav-toggle {
+    display: none;
+  }
+
+  .hero__grid {
+    grid-template-columns: minmax(0, 1fr) minmax(0, 0.9fr);
+    align-items: center;
+  }
+
+  .hero__stats {
+    grid-template-columns: repeat(3, auto);
+  }
+
+  .dashboard {
+    grid-template-columns: 1.15fr 1fr;
+  }
+
+  .cta__inner {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .site-footer__grid {
+    grid-template-columns: 1.3fr 1fr;
+    align-items: start;
+  }
+
+  .site-footer__bottom-inner {
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/static/js/navigation.js
+++ b/static/js/navigation.js
@@ -1,0 +1,45 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const toggle = document.querySelector('.nav-toggle');
+  const nav = document.getElementById('primary-navigation');
+
+  if (!toggle || !nav) {
+    return;
+  }
+
+  const closeOnEscape = (event) => {
+    if (event.key === 'Escape') {
+      setOpenState(false);
+      toggle.focus();
+    }
+  };
+
+  const setOpenState = (isOpen) => {
+    toggle.setAttribute('aria-expanded', String(isOpen));
+    nav.classList.toggle('is-open', isOpen);
+    document.body.classList.toggle('nav-open', isOpen);
+    toggle.classList.toggle('is-active', isOpen);
+
+    if (isOpen) {
+      document.addEventListener('keydown', closeOnEscape);
+    } else {
+      document.removeEventListener('keydown', closeOnEscape);
+    }
+  };
+
+  toggle.addEventListener('click', () => {
+    const isOpen = toggle.getAttribute('aria-expanded') === 'true';
+    setOpenState(!isOpen);
+  });
+
+  nav.addEventListener('click', (event) => {
+    if (event.target instanceof HTMLAnchorElement && toggle.offsetParent !== null) {
+      setOpenState(false);
+    }
+  });
+
+  window.addEventListener('resize', () => {
+    if (window.innerWidth >= 768) {
+      setOpenState(false);
+    }
+  });
+});

--- a/templates/admin/posts.html
+++ b/templates/admin/posts.html
@@ -1,0 +1,93 @@
+{% extends 'base.html' %}
+
+{% block title %}Fixly.dev Dashboard – Publish blog posts{% endblock %}
+
+{% block hero %}
+<section class="hero hero--dashboard">
+  <div class="container hero--dashboard__inner">
+    <div>
+      <p class="eyebrow">Creator dashboard</p>
+      <h1 class="hero__title">Share updates and guides on the Fixly.dev blog.</h1>
+      <p class="hero__description">Write your story, set an excerpt, and publish it instantly to the blog section and archive.</p>
+    </div>
+    <div class="hero__meta hero__meta--dashboard">
+      <div>
+        <strong>{{ posts|length }}</strong>
+        <span>Total posts</span>
+      </div>
+      <div>
+        <strong>{{ posts|selectattr('is_published')|list|length }}</strong>
+        <span>Published</span>
+      </div>
+    </div>
+  </div>
+  <div class="dashboard__switcher">
+    <a class="dashboard__switcher-link" href="{{ admin_tools_url }}">Manage tools</a>
+    <span aria-hidden="true">•</span>
+    <span class="dashboard__switcher-current">Manage blog</span>
+  </div>
+</section>
+{% endblock %}
+
+{% block content %}
+<section class="section section--dashboard">
+  <div class="container dashboard">
+    <div class="dashboard__panel">
+      <h2>Publish a new post</h2>
+      <form method="post" class="form">
+        <label class="form__field">
+          <span>Post title</span>
+          <input type="text" name="title" placeholder="How we ship 400+ developer tools" required />
+        </label>
+        <label class="form__field">
+          <span>Excerpt</span>
+          <input type="text" name="excerpt" placeholder="Optional — a short summary for the blog listing" />
+        </label>
+        <label class="form__field">
+          <span>Full content</span>
+          <textarea name="content" rows="10" placeholder="Write your article using paragraphs to separate ideas." required></textarea>
+        </label>
+        <button class="button button--primary" type="submit">Publish post</button>
+      </form>
+    </div>
+    <div class="dashboard__panel">
+      <h2>Recent posts</h2>
+      {% if posts %}
+        <ul class="dashboard__list">
+          {% for post in posts %}
+            <li class="dashboard__item">
+              <div>
+                <h3>{{ post.title }}</h3>
+                <p>{{ post.excerpt }}</p>
+                <div class="dashboard__meta">
+                  <span>Updated {{ post.created_at.strftime('%b %d, %Y') }}</span>
+                  <span>Status: {{ 'Live' if post.is_published else 'Hidden' }}</span>
+                </div>
+              </div>
+              <div class="dashboard__actions">
+                <a
+                  class="button button--ghost{% if not post.is_published %} button--disabled{% endif %}"
+                  href="{{ url_for('blog_detail', slug=post.slug) }}"
+                  {% if not post.is_published %}aria-disabled="true" tabindex="-1"{% endif %}
+                >
+                  View
+                </a>
+                <form method="post" action="{{ url_for('toggle_post', post_id=post.id) }}">
+                  <button type="submit" class="button button--secondary">
+                    {% if post.is_published %}Hide{% else %}Publish{% endif %}
+                  </button>
+                </form>
+              </div>
+            </li>
+          {% endfor %}
+        </ul>
+      {% else %}
+        <div class="empty-state empty-state--dashboard">
+          <h3>No posts yet.</h3>
+          <p>Share your first announcement to populate the Fixly.dev blog.</p>
+        </div>
+      {% endif %}
+    </div>
+  </div>
+</section>
+{% endblock %}

--- a/templates/admin/tools.html
+++ b/templates/admin/tools.html
@@ -22,6 +22,11 @@
     </div>
   </div>
 </section>
+  <div class="dashboard__switcher">
+    <span class="dashboard__switcher-current">Manage tools</span>
+    <span aria-hidden="true">•</span>
+    <a class="dashboard__switcher-link" href="{{ admin_posts_url }}">Manage blog</a>
+  </div>
 {% endblock %}
 
 {% block content %}

--- a/templates/admin/tools.html
+++ b/templates/admin/tools.html
@@ -1,0 +1,88 @@
+{% extends 'base.html' %}
+
+{% block title %}Fixly.dev Dashboard – Publish developer tools{% endblock %}
+
+{% block hero %}
+<section class="hero hero--dashboard">
+  <div class="container hero--dashboard__inner">
+    <div>
+      <p class="eyebrow">Creator dashboard</p>
+      <h1 class="hero__title">Publish a tool and see it go live instantly.</h1>
+      <p class="hero__description">Add the title, summary, and long-form content for your tool. Fixly.dev will craft the page and feature it on the catalog.</p>
+    </div>
+    <div class="hero__meta hero__meta--dashboard">
+      <div>
+        <strong>{{ tools|length }}</strong>
+        <span>Total tools</span>
+      </div>
+      <div>
+        <strong>{{ tools|selectattr('is_published')|list|length }}</strong>
+        <span>Published</span>
+      </div>
+    </div>
+  </div>
+</section>
+{% endblock %}
+
+{% block content %}
+<section class="section section--dashboard">
+  <div class="container dashboard">
+    <div class="dashboard__panel">
+      <h2>Publish a new tool</h2>
+      <form method="post" class="form">
+        <label class="form__field">
+          <span>Tool title</span>
+          <input type="text" name="title" placeholder="Launchpad CLI" required />
+        </label>
+        <label class="form__field">
+          <span>Summary</span>
+          <input type="text" name="summary" placeholder="Describe the value in one sentence" required />
+        </label>
+        <label class="form__field">
+          <span>Full content</span>
+          <textarea name="content" rows="8" placeholder="Share onboarding steps, features, and upgrade paths." required></textarea>
+        </label>
+        <button class="button button--primary" type="submit">Publish tool</button>
+      </form>
+    </div>
+    <div class="dashboard__panel">
+      <h2>Recently created</h2>
+      {% if tools %}
+        <ul class="dashboard__list">
+          {% for tool in tools %}
+            <li class="dashboard__item">
+              <div>
+                <h3>{{ tool.title }}</h3>
+                <p>{{ tool.summary }}</p>
+                <div class="dashboard__meta">
+                  <span>Updated {{ tool.created_at.strftime('%b %d, %Y') }}</span>
+                  <span>Status: {{ 'Live' if tool.is_published else 'Hidden' }}</span>
+                </div>
+              </div>
+              <div class="dashboard__actions">
+                <a
+                  class="button button--ghost{% if not tool.is_published %} button--disabled{% endif %}"
+                  href="{{ url_for('tool_detail', slug=tool.slug) }}"
+                  {% if not tool.is_published %}aria-disabled="true" tabindex="-1"{% endif %}
+                >
+                  View
+                </a>
+                <form method="post" action="{{ url_for('toggle_tool', tool_id=tool.id) }}">
+                  <button type="submit" class="button button--secondary">
+                    {% if tool.is_published %}Hide{% else %}Publish{% endif %}
+                  </button>
+                </form>
+              </div>
+            </li>
+          {% endfor %}
+        </ul>
+      {% else %}
+        <div class="empty-state empty-state--dashboard">
+          <h3>No tools yet.</h3>
+          <p>Create your first tool to populate the catalog on the Fixly.dev homepage.</p>
+        </div>
+      {% endif %}
+    </div>
+  </div>
+</section>
+{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta
+      name="description"
+      content="Fixly.dev is the SaaS control center for shipping 400+ developer automation tools with beautiful dashboards and instant deployments."
+    />
+    <title>{% block title %}Fixly.dev – Build a galaxy of developer tools{% endblock %}</title>
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/main.css') }}" />
+    {% block extra_head %}{% endblock %}
+  </head>
+  <body class="page">
+    <a class="skip-link" href="#content">Skip to content</a>
+    {% include 'partials/_header.html' %}
+    <main id="content" class="page__content" tabindex="-1">
+      {% with messages = get_flashed_messages(with_categories=True) %}
+        {% if messages %}
+          <div class="flash-region" role="status" aria-live="polite">
+            {% for category, message in messages %}
+              <div class="flash flash--{{ category }}">{{ message }}</div>
+            {% endfor %}
+          </div>
+        {% endif %}
+      {% endwith %}
+      {% block hero %}{% endblock %}
+      {% block content %}{% endblock %}
+    </main>
+    {% include 'partials/_footer.html' %}
+    <script src="{{ url_for('static', filename='js/navigation.js') }}" defer></script>
+    {% block extra_scripts %}{% endblock %}
+  </body>
+</html>

--- a/templates/blog_detail.html
+++ b/templates/blog_detail.html
@@ -1,0 +1,23 @@
+{% extends 'base.html' %}
+
+{% block title %}{{ post.title }} – Fixly.dev Blog{% endblock %}
+
+{% block hero %}
+<section class="hero hero--blog-detail">
+  <div class="container hero--blog-detail__inner">
+    <p class="eyebrow"><a href="{{ url_for('blog_index') }}" class="hero__breadcrumb">← Fixly.dev blog</a></p>
+    <h1 class="hero__title">{{ post.title }}</h1>
+    <p class="hero__meta">Published {{ post.created_at.strftime('%B %d, %Y') }}</p>
+  </div>
+</section>
+{% endblock %}
+
+{% block content %}
+<article class="section section--blog-detail">
+  <div class="container blog-article">
+    {% for paragraph in post.content|paragraphs %}
+      <p>{{ paragraph }}</p>
+    {% endfor %}
+  </div>
+</article>
+{% endblock %}

--- a/templates/blog_index.html
+++ b/templates/blog_index.html
@@ -1,0 +1,50 @@
+{% extends 'base.html' %}
+
+{% block title %}Fixly.dev Blog – Stories for building developer tools{% endblock %}
+
+{% block hero %}
+<section class="hero hero--blog">
+  <div class="container hero--blog__inner">
+    <div>
+      <p class="eyebrow">Fixly.dev blog</p>
+      <h1 class="hero__title">Ideas, launch playbooks, and product announcements.</h1>
+      <p class="hero__description">
+        Stay ahead with Fixly.dev. We share the research, frameworks, and stories powering 400+ developer automation tools.
+      </p>
+      <div class="hero__actions">
+        <a class="button button--primary" href="{{ admin_posts_url }}">Write a new post</a>
+        <a class="button button--ghost" href="{{ brand_url }}">Back to homepage</a>
+      </div>
+    </div>
+  </div>
+</section>
+{% endblock %}
+
+{% block content %}
+<section class="section section--blog-index">
+  <div class="container">
+    {% if posts %}
+      <div class="blog-grid blog-grid--index">
+        {% for post in posts %}
+          <article class="blog-card blog-card--index">
+            <header class="blog-card__header">
+              <p class="blog-card__eyebrow">Published {{ post.created_at.strftime('%b %d, %Y') }}</p>
+              <h2 class="blog-card__title"><a href="{{ url_for('blog_detail', slug=post.slug) }}">{{ post.title }}</a></h2>
+            </header>
+            <p class="blog-card__excerpt">{{ post.excerpt }}</p>
+            <footer class="blog-card__footer">
+              <a class="blog-card__link" href="{{ url_for('blog_detail', slug=post.slug) }}">Read post →</a>
+            </footer>
+          </article>
+        {% endfor %}
+      </div>
+    {% else %}
+      <div class="empty-state">
+        <h2>No posts have been published yet.</h2>
+        <p>Draft your first article from the dashboard to start sharing your product journey.</p>
+        <a class="button button--primary" href="{{ admin_posts_url }}">Create a post</a>
+      </div>
+    {% endif %}
+  </div>
+</section>
+{% endblock %}

--- a/templates/home.html
+++ b/templates/home.html
@@ -1,0 +1,218 @@
+{% extends 'base.html' %}
+
+{% block title %}Fixly.dev – The SaaS launchpad for developer tools{% endblock %}
+
+{% block hero %}
+<section class="hero">
+  <div class="container hero__grid">
+    <div class="hero__content">
+      <p class="eyebrow">The Fixly.dev control center</p>
+      <h1 class="hero__title">Design, launch, and scale 400+ developer tools in one beautiful workspace.</h1>
+      <p class="hero__description">
+        Fixly.dev bundles content publishing, documentation, billing, status pages, and AI copilots so your next tool is live
+        in minutes. Publish from the dashboard and your tool instantly appears on the public catalog.
+      </p>
+      <div class="hero__actions">
+        <a class="button button--primary" href="{{ admin_tools_url }}">Publish a tool</a>
+        <a class="button button--ghost" href="#platform">Explore the platform</a>
+      </div>
+      <dl class="hero__stats">
+        <div>
+          <dt>Tools orchestrated</dt>
+          <dd>400+</dd>
+        </div>
+        <div>
+          <dt>Average go-live time</dt>
+          <dd>9 minutes</dd>
+        </div>
+        <div>
+          <dt>Teams building today</dt>
+          <dd>28k+</dd>
+        </div>
+      </dl>
+    </div>
+    <div class="hero__media">
+      <div class="dashboard-card">
+        <header class="dashboard-card__header">
+          <span class="dashboard-card__eyebrow">fixly.dev/dashboard</span>
+          <strong>Tool publishing</strong>
+        </header>
+        <ul class="dashboard-card__list">
+          {% if tools %}
+            {% for tool in tools[:4] %}
+              <li>
+                <span class="dashboard-card__status">Live</span>
+                <span class="dashboard-card__name">{{ tool.title }}</span>
+                <span class="dashboard-card__cta">{{ tool.created_at.strftime('%b %d') }}</span>
+              </li>
+            {% endfor %}
+          {% else %}
+            <li>
+              <span class="dashboard-card__status">Ready</span>
+              <span class="dashboard-card__name">Create your first tool</span>
+              <span class="dashboard-card__cta">Start</span>
+            </li>
+            <li>
+              <span class="dashboard-card__status">Guide</span>
+              <span class="dashboard-card__name">Click “Publish a tool”</span>
+              <span class="dashboard-card__cta">→</span>
+            </li>
+          {% endif %}
+        </ul>
+        <footer class="dashboard-card__footer">
+          <span>Automations on</span>
+          <strong>Fixly.dev</strong>
+        </footer>
+      </div>
+    </div>
+  </div>
+</section>
+{% endblock %}
+
+{% block content %}
+<section class="section" id="tools">
+  <div class="container">
+    <div class="section__intro">
+      <p class="eyebrow">Tool catalog</p>
+      <h2 class="section__title">Every published tool gets a polished landing page instantly.</h2>
+      <p class="section__description">
+        Showcase onboarding checklists, embed documentation, and share demos without touching a CMS. Tools you publish from the
+        dashboard are automatically organized here for developers to explore.
+      </p>
+    </div>
+    {% if tools %}
+      <div class="tool-grid">
+        {% for tool in tools %}
+          <article class="tool-card">
+            <header>
+              <h3>{{ tool.title }}</h3>
+              <span class="tool-card__badge">Live</span>
+            </header>
+            <p>{{ tool.summary }}</p>
+            <div class="tool-card__meta">
+              <span>Updated {{ tool.created_at.strftime('%b %d, %Y') }}</span>
+            </div>
+            <a class="tool-card__link" href="{{ url_for('tool_detail', slug=tool.slug) }}">Open tool →</a>
+          </article>
+        {% endfor %}
+      </div>
+    {% else %}
+      <div class="empty-state">
+        <h3>No tools yet — but the stage is set.</h3>
+        <p>Publish from the dashboard and your launch-ready page will appear in this catalog automatically.</p>
+        <a class="button button--primary" href="{{ admin_tools_url }}">Create your first tool</a>
+      </div>
+    {% endif %}
+  </div>
+</section>
+
+<section class="section section--accent" id="platform">
+  <div class="container">
+    <div class="section__intro">
+      <p class="eyebrow">Platform map</p>
+      <h2 class="section__title">A unified control plane for developer success.</h2>
+      <p class="section__description">
+        Fixly.dev pairs your tools with billing, analytics, documentation, and community experiences that feel handcrafted for every
+        customer.
+      </p>
+    </div>
+    <div class="feature-mosaic">
+      <article class="feature-tile">
+        <h3>Visual editor</h3>
+        <p>Compose hero sections, highlights, and launch notes without a single line of CSS.</p>
+      </article>
+      <article class="feature-tile">
+        <h3>Usage intelligence</h3>
+        <p>Understand activation funnels, retention, and team adoption with real-time dashboards.</p>
+      </article>
+      <article class="feature-tile">
+        <h3>Billing ready</h3>
+        <p>Connect Stripe or Paddle in one click and start charging for premium automations.</p>
+      </article>
+      <article class="feature-tile">
+        <h3>White-label docs</h3>
+        <p>Deploy documentation portals, changelogs, and SDK guides under your Fixly.dev domain.</p>
+      </article>
+    </div>
+  </div>
+</section>
+
+<section class="section" id="automation">
+  <div class="container">
+    <div class="section__intro">
+      <p class="eyebrow">Automation studio</p>
+      <h2 class="section__title">Let AI copilots personalize each developer's experience.</h2>
+      <p class="section__description">
+        Give builders a concierge that understands their stack, autocompletes configuration, and keeps every workflow humming.
+      </p>
+    </div>
+    <div class="automation-grid">
+      <article class="automation-card">
+        <h3>Blueprint generator</h3>
+        <p>Feed Fixly.dev a few prompts and instantly receive a branded tool page with copy, CTA, and visuals.</p>
+      </article>
+      <article class="automation-card">
+        <h3>Guided onboarding</h3>
+        <p>Deliver interactive walkthroughs tailored to language, framework, and compliance requirements.</p>
+      </article>
+      <article class="automation-card">
+        <h3>Lifecycle nudges</h3>
+        <p>Trigger in-app tips, emails, and Slack alerts whenever teams hit milestones inside your tools.</p>
+      </article>
+    </div>
+  </div>
+</section>
+
+<section class="section section--pricing" id="pricing">
+  <div class="container">
+    <div class="section__intro">
+      <p class="eyebrow">Pricing plans</p>
+      <h2 class="section__title">Start free, launch faster.</h2>
+      <p class="section__description">Simple tiers that scale with every new tool you offer on Fixly.dev.</p>
+    </div>
+    <div class="pricing-grid">
+      <article class="pricing-card">
+        <h3>Starter</h3>
+        <p class="pricing-card__price">$0</p>
+        <ul>
+          <li>Publish unlimited free tools</li>
+          <li>Hosted on fixly.dev</li>
+          <li>Community analytics</li>
+        </ul>
+        <a class="button button--ghost" href="{{ admin_tools_url }}">Launch now</a>
+      </article>
+      <article class="pricing-card pricing-card--featured">
+        <h3>Scale</h3>
+        <p class="pricing-card__price">$129<span>/mo</span></p>
+        <ul>
+          <li>Custom domains & SSO</li>
+          <li>Advanced automation studio</li>
+          <li>Usage-based billing integrations</li>
+        </ul>
+        <a class="button button--primary" href="#demo">Book a demo</a>
+      </article>
+      <article class="pricing-card">
+        <h3>Enterprise</h3>
+        <p class="pricing-card__price">Let's talk</p>
+        <ul>
+          <li>Dedicated success engineer</li>
+          <li>Audit trails & compliance suite</li>
+          <li>Private AI model hosting</li>
+        </ul>
+        <a class="button button--ghost" href="#support">Contact us</a>
+      </article>
+    </div>
+  </div>
+</section>
+
+<section class="cta" id="demo">
+  <div class="container cta__inner">
+    <div>
+      <p class="eyebrow">Ready to ship?</p>
+      <h2>Showcase your next developer experience on {{ brand_domain }} today.</h2>
+      <p>Create, personalize, and launch your automations in under ten minutes with the Fixly.dev dashboard.</p>
+    </div>
+    <a class="button button--primary" href="{{ admin_tools_url }}">Open the dashboard</a>
+  </div>
+</section>
+{% endblock %}

--- a/templates/home.html
+++ b/templates/home.html
@@ -106,6 +106,44 @@
   </div>
 </section>
 
+<section class="section section--blog" id="blog">
+  <div class="container">
+    <div class="section__intro">
+      <p class="eyebrow">Fixly.dev blog</p>
+      <h2 class="section__title">Stories, launch guides, and changelog highlights.</h2>
+      <p class="section__description">
+        Go behind the scenes with the Fixly.dev team. Learn how top developer companies ship faster, catch the latest
+        platform updates, and explore automation strategies for your next tool.
+      </p>
+    </div>
+    {% if posts %}
+      <div class="blog-grid">
+        {% for post in posts %}
+          <article class="blog-card">
+            <header class="blog-card__header">
+              <p class="blog-card__eyebrow">Published {{ post.created_at.strftime('%b %d, %Y') }}</p>
+              <h3 class="blog-card__title"><a href="{{ url_for('blog_detail', slug=post.slug) }}">{{ post.title }}</a></h3>
+            </header>
+            <p class="blog-card__excerpt">{{ post.excerpt }}</p>
+            <footer class="blog-card__footer">
+              <a class="blog-card__link" href="{{ url_for('blog_detail', slug=post.slug) }}">Read post →</a>
+            </footer>
+          </article>
+        {% endfor %}
+      </div>
+      <div class="section__cta">
+        <a class="button button--ghost" href="{{ blog_url }}">Browse all posts</a>
+      </div>
+    {% else %}
+      <div class="empty-state">
+        <h3>Your Fixly.dev blog is waiting.</h3>
+        <p>Publish your first article to share stories, product announcements, and guides with developers everywhere.</p>
+        <a class="button button--primary" href="{{ admin_posts_url }}">Write a post</a>
+      </div>
+    {% endif %}
+  </div>
+</section>
+
 <section class="section section--accent" id="platform">
   <div class="container">
     <div class="section__intro">

--- a/templates/partials/_footer.html
+++ b/templates/partials/_footer.html
@@ -1,0 +1,52 @@
+<footer class="site-footer" role="contentinfo" id="support">
+  <div class="container site-footer__grid">
+    <div class="site-footer__brand">
+      <span class="site-footer__mark" aria-hidden="true">⚙️</span>
+      <h2 class="site-footer__title">Operate Fixly.dev like a pro team.</h2>
+      <p class="site-footer__description">
+        Spin up 400+ production-ready developer experiences with templates, observability, billing, and launch metrics that
+        customers love.
+      </p>
+      <div class="site-footer__meta">Serving makers in 120+ countries.</div>
+    </div>
+    <div class="site-footer__links">
+      <div class="site-footer__column">
+        <h3 class="site-footer__heading">Product</h3>
+        <ul>
+          <li><a href="#tools">Tool catalog</a></li>
+          <li><a href="#platform">Platform map</a></li>
+          <li><a href="#automation">AI assistants</a></li>
+          <li><a href="#pricing">Pricing</a></li>
+        </ul>
+      </div>
+      <div class="site-footer__column">
+        <h3 class="site-footer__heading">Company</h3>
+        <ul>
+          <li><a href="#about">About Fixly.dev</a></li>
+          <li><a href="#careers">Careers</a></li>
+          <li><a href="#press">Press kit</a></li>
+          <li><a href="#partners">Partner with us</a></li>
+        </ul>
+      </div>
+      <div class="site-footer__column">
+        <h3 class="site-footer__heading">Resources</h3>
+        <ul>
+          <li><a href="#docs">Docs & API</a></li>
+          <li><a href="#changelog">Changelog</a></li>
+          <li><a href="#blog">Blog</a></li>
+          <li><a href="{{ admin_tools_url }}">Creator dashboard</a></li>
+        </ul>
+      </div>
+    </div>
+  </div>
+  <div class="site-footer__bottom">
+    <div class="container site-footer__bottom-inner">
+      <p class="site-footer__copyright">© {{ current_year }} {{ brand_name }}. All rights reserved.</p>
+      <div class="site-footer__policies">
+        <a href="#privacy">Privacy</a>
+        <a href="#terms">Terms</a>
+        <a href="#security">Security</a>
+      </div>
+    </div>
+  </div>
+</footer>

--- a/templates/partials/_footer.html
+++ b/templates/partials/_footer.html
@@ -33,7 +33,7 @@
         <ul>
           <li><a href="#docs">Docs & API</a></li>
           <li><a href="#changelog">Changelog</a></li>
-          <li><a href="#blog">Blog</a></li>
+          <li><a href="{{ blog_url }}">Blog</a></li>
           <li><a href="{{ admin_tools_url }}">Creator dashboard</a></li>
         </ul>
       </div>

--- a/templates/partials/_header.html
+++ b/templates/partials/_header.html
@@ -22,10 +22,12 @@
         <li class="primary-nav__item"><a href="#platform" class="primary-nav__link">Platform</a></li>
         <li class="primary-nav__item"><a href="#automation" class="primary-nav__link">Automation</a></li>
         <li class="primary-nav__item"><a href="#pricing" class="primary-nav__link">Pricing</a></li>
+        <li class="primary-nav__item"><a href="{{ blog_url }}" class="primary-nav__link">Blog</a></li>
         <li class="primary-nav__item"><a href="#support" class="primary-nav__link">Support</a></li>
       </ul>
       <div class="primary-nav__cta">
         <a class="primary-nav__link primary-nav__link--muted" href="{{ admin_tools_url }}">Dashboard</a>
+        <a class="primary-nav__link primary-nav__link--muted" href="{{ admin_posts_url }}">Write</a>
         <a class="button button--primary" href="#demo">Launch Fixly</a>
       </div>
     </nav>

--- a/templates/partials/_header.html
+++ b/templates/partials/_header.html
@@ -1,0 +1,41 @@
+<header class="site-header" role="banner">
+  <div class="site-header__inner container">
+    <a class="brand" href="{{ brand_url }}">
+      <span class="brand__mark" aria-hidden="true">⚡</span>
+      <span class="brand__text">
+        {{ brand_name }}
+        <span class="brand__subtext">{{ brand_tagline }}</span>
+      </span>
+    </a>
+    <button
+      class="nav-toggle"
+      type="button"
+      aria-expanded="false"
+      aria-controls="primary-navigation"
+    >
+      <span class="nav-toggle__label">Menu</span>
+      <span class="nav-toggle__icon" aria-hidden="true"><span></span></span>
+    </button>
+    <nav id="primary-navigation" class="primary-nav" aria-label="Main navigation">
+      <ul class="primary-nav__list">
+        <li class="primary-nav__item"><a href="#tools" class="primary-nav__link">Tools</a></li>
+        <li class="primary-nav__item"><a href="#platform" class="primary-nav__link">Platform</a></li>
+        <li class="primary-nav__item"><a href="#automation" class="primary-nav__link">Automation</a></li>
+        <li class="primary-nav__item"><a href="#pricing" class="primary-nav__link">Pricing</a></li>
+        <li class="primary-nav__item"><a href="#support" class="primary-nav__link">Support</a></li>
+      </ul>
+      <div class="primary-nav__cta">
+        <a class="primary-nav__link primary-nav__link--muted" href="{{ admin_tools_url }}">Dashboard</a>
+        <a class="button button--primary" href="#demo">Launch Fixly</a>
+      </div>
+    </nav>
+  </div>
+  <div class="site-header__announcement" role="presentation">
+    <div class="container site-header__announcement-inner">
+      <p class="site-header__announcement-text">
+        Fixly.dev now orchestrates full-stack developer portals across cloud, data, and AI teams.
+      </p>
+      <a class="site-header__announcement-link" href="#changelog">See what's new →</a>
+    </div>
+  </div>
+</header>

--- a/templates/tool_detail.html
+++ b/templates/tool_detail.html
@@ -1,0 +1,38 @@
+{% extends 'base.html' %}
+
+{% block title %}{{ tool.title }} – Fixly.dev{% endblock %}
+
+{% block hero %}
+<section class="hero hero--detail">
+  <div class="container hero--detail__inner">
+    <a class="back-link" href="{{ url_for('index') }}">← Back to catalog</a>
+    <h1 class="hero__title">{{ tool.title }}</h1>
+    <p class="hero__description">{{ tool.summary }}</p>
+    <div class="hero__meta">
+      <span>Published {{ tool.created_at.strftime('%B %d, %Y') }}</span>
+      <span>Hosted on {{ brand_domain }}</span>
+    </div>
+  </div>
+</section>
+{% endblock %}
+
+{% block content %}
+<section class="section section--article">
+  <div class="container article-body">
+    {% for paragraph in tool.content|paragraphs %}
+      <p>{{ paragraph }}</p>
+    {% endfor %}
+  </div>
+</section>
+
+<section class="cta cta--detail">
+  <div class="container cta__inner">
+    <div>
+      <p class="eyebrow">Share Fixly.dev</p>
+      <h2>Bring your developer ecosystem to life.</h2>
+      <p>Publish more tools, craft guided journeys, and keep everything discoverable in one place.</p>
+    </div>
+    <a class="button button--primary" href="{{ admin_tools_url }}">Open dashboard</a>
+  </div>
+</section>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add a SQLAlchemy-powered Tool model plus admin routes to publish, list, and toggle catalog entries
- refresh the Fixly.dev homepage and add tool detail views that render published content instantly
- redesign the shared layout, navigation, footer, and styling for the new Fixly.dev SaaS aesthetic

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68d3d849dbe48321872b47f1b0995301